### PR TITLE
Changed Memcached link

### DIFF
--- a/seastar-applications/index.html
+++ b/seastar-applications/index.html
@@ -40,7 +40,7 @@
         <li><a href="https://github.com/fastio/pedis">Pedis</a>: Redis-compatible data structure store</li>
         <li><a href="http://www.scylladb.com/">Scylla</a>: NoSQL column-store database, compatible with Apache Cassandra at 10x the throughput</li>
         <li>Seastar HTTPD: web server</li>
-        <li><a href="http://www.seastar-project.org/memcached/">Seastar Memcached</a>: a fast server for the Memcache key-value store</li>
+        <li><a href="https://github.com/scylladb/seastar/wiki/Running-Seastar-Memcached">Seastar Memcached</a>: a fast server for the Memcache key-value store</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Was pointing to this (which does not exist):
http://seastar.io/memcached/

Pointed instead to here:
https://github.com/scylladb/seastar/wiki/Running-Seastar-Memcached