### PR TITLE
Fix memcache link

### DIFF
--- a/content/seastar-applications.md
+++ b/content/seastar-applications.md
@@ -9,4 +9,4 @@ While many applications can benefit from high performance, Seastar is currently 
 * [Pedis](https://github.com/fastio/pedis): Redis-compatible data structure store
 * [Scylla](http://www.scylladb.com/): NoSQL column-store database, compatible with Apache Cassandra at 10x the throughput
 * Seastar HTTPD: web server
-* [Seastar Memcached](http://www.seastar-project.org/memcached/): a fast server for the Memcache key-value store
+* [Seastar Memcached](https://github.com/scylladb/seastar/wiki/Running-Seastar-Memcached): a fast server for the Memcache key-value store

--- a/seastar-applications/index.html
+++ b/seastar-applications/index.html
@@ -40,7 +40,7 @@
         <li><a href="https://github.com/fastio/pedis">Pedis</a>: Redis-compatible data structure store</li>
         <li><a href="http://www.scylladb.com/">Scylla</a>: NoSQL column-store database, compatible with Apache Cassandra at 10x the throughput</li>
         <li>Seastar HTTPD: web server</li>
-        <li><a href="https://github.com/scylladb/seastar/wiki/Running-Seastar-Memcached">Seastar Memcached</a>: a fast server for the Memcache key-value store</li>
+        <li><a href="http://www.seastar-project.org/memcached/">Seastar Memcached</a>: a fast server for the Memcache key-value store</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This PR fixes the Memcache link:
- revert the wrong commit that changes the HTML
- update the MD file with the right link

To test locally: 

```
hugo server -D
```
